### PR TITLE
fixing the compartment CH(t)

### DIFF
--- a/src/markov.jl
+++ b/src/markov.jl
@@ -147,6 +147,8 @@ function update_prob!(Pᵢᵍ::Array{Float64, 2},
                 aux = ρˢᵍ[g, i, t]
                 ρˢᵍ[g, i, t] -= CHᵢᵍ[g, i, t]
                 CHᵢᵍ[g, i, t + 1] = CHᵢ * aux
+            else 
+                CHᵢᵍ[g, i, t + 1] = CHᵢᵍ[g, i, t]
             end
         end
     end


### PR DESCRIPTION
When a level of confinement is applied it is maintained until further notice.Therefore if t != tc then CH(t+1) = CH(t). 
Previously the compartment CH(t) was updated only when t = tc and then was 0 until a new confinement was specified. This implementation did not produce errors because a confinement level was provided for every time step t.